### PR TITLE
Add scraping script and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # parser_viaggi
-Progetto node.js e python per parser di viaggi. Collegato a codex.
+
+Questo progetto contiene uno script Python per effettuare lo scraping delle offerte presenti su <https://offerte.caesartour.it/last-second.aspx> e salvarle in un database SQLite. 
+È presente anche una piccola dashboard realizzata in Node.js che consente di filtrare e ordinare i risultati.
+
+## Requisiti
+- Python 3 con i pacchetti `requests` e `beautifulsoup4`.
+- Node.js (per avviare la dashboard).
+
+## Utilizzo
+1. **Esecuzione dello scraper**
+   ```bash
+   python scraper.py
+   ```
+   Lo script crea (se non esiste) il database `db.sqlite` e inserisce le offerte recuperate.
+
+2. **Avvio della dashboard**
+   Dopo aver installato le dipendenze (`npm install`), avviare:
+   ```bash
+   npm start
+   ```
+   La dashboard sarà disponibile su <http://localhost:3000>.
+
+La pagina consente di filtrare per Paese, formula e aeroporto, nonché di ordinare i risultati cliccando sull'intestazione delle colonne.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "parser_viaggi_dashboard",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="UTF-8">
+<title>Dashboard Viaggi</title>
+<style>
+body { font-family: Arial, sans-serif; }
+#filters { margin-bottom: 1em; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 4px; }
+th { cursor: pointer; background: #eee; }
+</style>
+</head>
+<body>
+<h1>Offerte Viaggi</h1>
+<div id="filters"></div>
+<table id="offers">
+<thead>
+<tr><th data-field="country">Paese</th><th data-field="name">Struttura</th><th data-field="date">Partenza</th><th data-field="duration">Durata</th><th data-field="airport">Aeroporto</th><th data-field="formula">Tipo</th><th data-field="price">Prezzo</th><th data-field="transfer">Transfer</th></tr>
+</thead>
+<tbody></tbody>
+</table>
+<script>
+let sortBy = '';
+async function loadFilters(){
+  const data = await fetch('/api/filters').then(r=>r.json());
+  const div = document.getElementById('filters');
+  div.innerHTML = '';
+  for(const key in data){
+    const select = document.createElement('select');
+    select.id = key;
+    const opt = document.createElement('option');
+    opt.value='';
+    opt.textContent=`Tutti i ${key}`;
+    select.appendChild(opt);
+    data[key].forEach(v=>{
+      const o = document.createElement('option');
+      o.value=v;
+      o.textContent=v;
+      select.appendChild(o);
+    });
+    select.onchange = loadOffers;
+    div.appendChild(select);
+  }
+}
+async function loadOffers(){
+  const params = new URLSearchParams();
+  ['country','formula','airport'].forEach(id=>{
+    const val = document.getElementById(id)?.value;
+    if(val) params.append(id,val);
+  });
+  if(sortBy) params.append('sortBy', sortBy);
+  const data = await fetch('/api/offers?'+params.toString()).then(r=>r.json());
+  const tbody = document.querySelector('#offers tbody');
+  tbody.innerHTML = '';
+  data.forEach(o=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${o.country}</td><td>${o.name}</td><td>${o.date}</td><td>${o.duration}</td><td>${o.airport}</td><td>${o.formula}</td><td>${o.price}</td><td>${o.transfer ? 'si' : 'no'}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+document.querySelectorAll('th').forEach(th=>{
+  th.onclick = ()=>{ sortBy = th.dataset.field; loadOffers(); };
+});
+loadFilters().then(loadOffers);
+</script>
+</body>
+</html>

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,89 @@
+import re
+import sqlite3
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://offerte.caesartour.it/last-second.aspx"
+DB_PATH = "db.sqlite"
+
+# regex to parse offer information from text block
+OFFER_RE = re.compile(
+    r"""
+    (?P<country>[\w\s]+)\s*-\s*(?P<name>.*?)\s+
+    (?P<date>\d{2}/\d{2}/\d{4})\s+da\s+(?P<airport>.*?)\s+
+    (?P<duration>\d+\s+notti).*?
+    (?P<formula>AI|BB|HB|FB|RO|\w{2})?.*?
+    €(?P<price>[\d\.]+)
+    (?:.*?\bTRF\b)?
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def create_db():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS offers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            country TEXT,
+            name TEXT,
+            date TEXT,
+            duration TEXT,
+            airport TEXT,
+            price REAL,
+            formula TEXT,
+            transfer INTEGER
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_offer(info):
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """INSERT INTO offers(country,name,date,duration,airport,price,formula,transfer)
+        VALUES(?,?,?,?,?,?,?,?)""",
+        (
+            info.get("country"),
+            info.get("name"),
+            info.get("date"),
+            info.get("duration"),
+            info.get("airport"),
+            info.get("price"),
+            info.get("formula"),
+            info.get("transfer"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def parse_offers(html):
+    soup = BeautifulSoup(html, "html.parser")
+    items = soup.select(".last-second-item, .offer")
+    for item in items:
+        text = item.get_text(" ", strip=True)
+        match = OFFER_RE.search(text)
+        if match:
+            data = match.groupdict()
+            data["price"] = float(data["price"].replace(".", ""))
+            data["transfer"] = 1 if "TRF" in text.upper() else 0
+            save_offer(data)
+
+
+def main():
+    create_db()
+    try:
+        resp = requests.get(URL, timeout=10)
+        resp.raise_for_status()
+    except Exception as e:
+        print(f"Error fetching {URL}: {e}")
+        return
+    parse_offers(resp.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.js
+++ b/server.js
@@ -1,0 +1,61 @@
+import express from 'express';
+import sqlite3 from 'sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+const db = new sqlite3.Database('db.sqlite');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+function buildWhere(query) {
+  const clauses = [];
+  const params = [];
+  if (query.country) {
+    clauses.push('country = ?');
+    params.push(query.country);
+  }
+  if (query.formula) {
+    clauses.push('formula = ?');
+    params.push(query.formula);
+  }
+  if (query.airport) {
+    clauses.push('airport = ?');
+    params.push(query.airport);
+  }
+  const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+  return { where, params };
+}
+
+app.get('/api/offers', (req, res) => {
+  const { where, params } = buildWhere(req.query);
+  const sort = ['price', 'date', 'country'].includes(req.query.sortBy)
+    ? `ORDER BY ${req.query.sortBy}`
+    : '';
+  db.all(
+    `SELECT * FROM offers ${where} ${sort}`,
+    params,
+    (err, rows) => {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json(rows);
+    }
+  );
+});
+
+app.get('/api/filters', (req, res) => {
+  const result = {};
+  const fields = ['country', 'formula', 'airport'];
+  let pending = fields.length;
+  fields.forEach((f) => {
+    db.all(`SELECT DISTINCT ${f} FROM offers`, [], (err, rows) => {
+      if (!err) result[f] = rows.map((r) => r[f]);
+      if (--pending === 0) res.json(result);
+    });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Dashboard listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- create scraper.py to extract offer data and save to SQLite
- add a Node.js dashboard with Express
- provide simple web page for filtering and sorting
- document usage in README

## Testing
- `node --version`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688a1beac4888322ae9aa8da32ab3dc8