### PR TITLE
Enable offer refresh and improved scraper

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,16 +4,21 @@
 <meta charset="UTF-8">
 <title>Dashboard Viaggi</title>
 <style>
-body { font-family: Arial, sans-serif; }
+body { font-family: Arial, sans-serif; margin: 20px; }
+#controls { margin-bottom: 1em; }
 #filters { margin-bottom: 1em; }
 table { border-collapse: collapse; width: 100%; }
-th, td { border: 1px solid #ccc; padding: 4px; }
+th, td { border: 1px solid #ccc; padding: 6px; }
 th { cursor: pointer; background: #eee; }
+button { padding: 0.5em 1em; }
 </style>
 </head>
 <body>
 <h1>Offerte Viaggi</h1>
-<div id="filters"></div>
+<div id="controls">
+  <button id="refresh">Aggiorna offerte</button>
+  <div id="filters"></div>
+</div>
 <table id="offers">
 <thead>
 <tr><th data-field="country">Paese</th><th data-field="name">Struttura</th><th data-field="date">Partenza</th><th data-field="duration">Durata</th><th data-field="airport">Aeroporto</th><th data-field="formula">Tipo</th><th data-field="price">Prezzo</th><th data-field="transfer">Transfer</th></tr>
@@ -63,6 +68,13 @@ document.querySelectorAll('th').forEach(th=>{
   th.onclick = ()=>{ sortBy = th.dataset.field; loadOffers(); };
 });
 loadFilters().then(loadOffers);
+document.getElementById('refresh').onclick = async () => {
+  document.getElementById('refresh').disabled = true;
+  await fetch('/api/refresh', {method: 'POST'});
+  await loadFilters();
+  await loadOffers();
+  document.getElementById('refresh').disabled = false;
+};
 </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import sqlite3 from 'sqlite3';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
 
 const app = express();
 const db = new sqlite3.Database('db.sqlite');
@@ -54,6 +55,17 @@ app.get('/api/filters', (req, res) => {
       if (!err) result[f] = rows.map((r) => r[f]);
       if (--pending === 0) res.json(result);
     });
+  });
+});
+
+app.post('/api/refresh', (req, res) => {
+  const child = spawn('python', [path.join(__dirname, 'scraper.py')]);
+  child.on('close', (code) => {
+    if (code === 0) {
+      res.json({ status: 'ok' });
+    } else {
+      res.status(500).json({ error: 'scraper failed' });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- paginate scraper to fetch multiple pages
- expose POST `/api/refresh` endpoint to run scraper
- modernize dashboard with refresh button and styling

## Testing
- `python3 -m py_compile scraper.py`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_688a2142cacc8322a1f3630d667b8462